### PR TITLE
fix: Ensure stored session duration is non-negative

### DIFF
--- a/backend/apps/cloud/src/task-manager/task-manager.service.ts
+++ b/backend/apps/cloud/src/task-manager/task-manager.service.ts
@@ -745,7 +745,10 @@ export class TaskManagerService {
         toSave.push({
           psid,
           pid,
-          duration: Math.floor((Number(last) - Number(start)) / 1000), // convert to seconds
+          duration: Math.max(
+            0,
+            Math.floor((Number(last) - Number(start)) / 1000),
+          ), // convert to seconds, ensure non-negative
         })
         keysToDelete.push(key)
       }

--- a/backend/apps/community/src/task-manager/task-manager.service.ts
+++ b/backend/apps/community/src/task-manager/task-manager.service.ts
@@ -40,7 +40,10 @@ export class TaskManagerService {
         toSave.push({
           psid,
           pid,
-          duration: Math.floor((Number(last) - Number(start)) / 1000), // convert to seconds
+          duration: Math.max(
+            0,
+            Math.floor((Number(last) - Number(start)) / 1000),
+          ), // convert to seconds, ensure non-negative
         })
         keysToDelete.push(key)
       }


### PR DESCRIPTION
### Changes

Fixes the following error:

```
[Nest] 1273612  - 00/00/2025, 00:00:00 AM   ERROR [Scheduler] ClickHouseError: Unsigned type must not contain '-' symbol: (while reading the value of key duration): (at row 15)
: While executing ParallelParsingBlockInputFormat. 
    at ... {
  code: '72',
  type: 'CANNOT_PARSE_NUMBER'
}
```

### Community Edition support
- [x] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [x] This PR did not change any publicly documented endpoints
