### PR TITLE
fix: sessions with hourly timebucket have an empty chart

### DIFF
--- a/backend/apps/cloud/src/analytics/analytics.service.ts
+++ b/backend/apps/cloud/src/analytics/analytics.service.ts
@@ -2063,19 +2063,27 @@ export class AnalyticsService {
 
     switch (timeBucket) {
       case TimeBucketType.MINUTE:
+        djsFrom = djsFrom.startOf('minute')
+        format = 'YYYY-MM-DD HH:mm:ss'
+        break
+
       case TimeBucketType.HOUR:
+        djsFrom = djsFrom.startOf('hour')
         format = 'YYYY-MM-DD HH:mm:ss'
         break
 
       case TimeBucketType.DAY:
+        djsFrom = djsFrom.startOf('day')
         format = 'YYYY-MM-DD'
         break
 
       case TimeBucketType.MONTH:
+        djsFrom = djsFrom.startOf('month')
         format = 'YYYY-MM'
         break
 
       case TimeBucketType.YEAR:
+        djsFrom = djsFrom.startOf('year')
         format = 'YYYY'
         break
 

--- a/backend/apps/community/src/analytics/analytics.service.ts
+++ b/backend/apps/community/src/analytics/analytics.service.ts
@@ -1869,19 +1869,27 @@ export class AnalyticsService {
 
     switch (timeBucket) {
       case TimeBucketType.MINUTE:
+        djsFrom = djsFrom.startOf('minute')
+        format = 'YYYY-MM-DD HH:mm:ss'
+        break
+
       case TimeBucketType.HOUR:
+        djsFrom = djsFrom.startOf('hour')
         format = 'YYYY-MM-DD HH:mm:ss'
         break
 
       case TimeBucketType.DAY:
+        djsFrom = djsFrom.startOf('day')
         format = 'YYYY-MM-DD'
         break
 
       case TimeBucketType.MONTH:
+        djsFrom = djsFrom.startOf('month')
         format = 'YYYY-MM'
         break
 
       case TimeBucketType.YEAR:
+        djsFrom = djsFrom.startOf('year')
         format = 'YYYY'
         break
 


### PR DESCRIPTION
### Changes

If applicable, please describe what changes were made in this pull request.

### Community Edition support
- [ ] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [ ] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [ ] This PR did not change any publicly documented endpoints
