### PR TITLE
Fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ We welcome contributions! See the [contributing guide](./CONTRIBUTING.MD) and br
 
 If Swetrix is useful to you, **star the repo** — it genuinely helps a bootstrapped team and motivates us a lot 😊
 
-<a href="https://www.star-history.com/#swetrix/swetrix&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#swetrix/swetrix&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=swetrix/swetrix&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=swetrix/swetrix&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=swetrix/swetrix&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=swetrix/swetrix&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=swetrix/swetrix&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=swetrix/swetrix&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken. This switches it to an alternative that works without an API token so the chart displays correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History links and chart sources to use the new hosting domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->