### PR TITLE
(fix) Correct preset traffic analytics timeframes

### DIFF
--- a/backend/apps/cloud/src/analytics/analytics.service.ts
+++ b/backend/apps/cloud/src/analytics/analytics.service.ts
@@ -553,11 +553,14 @@ export const getLowestPossibleTimeBucket = (
       return TimeBucketType.HOUR
     }
 
-    if (period === '4w') {
+    // The finest buckets must match the frontend's per-period options
+    // (tbPeriodPairs), otherwise summary cards and the chart cover
+    // different boundaries
+    if (period === '4w' || period === '3M' || period === '12M') {
       return TimeBucketType.DAY
     }
 
-    if (period === '3M' || period === '12M' || period === '24M') {
+    if (period === '24M') {
       return TimeBucketType.MONTH
     }
 
@@ -1202,17 +1205,10 @@ export class AnalyticsService {
         groupFrom = djsNow.subtract(diff - 1, 'day').startOf(timeBucket)
         groupTo = djsNow
       } else {
-        if (period === '1d' || period === '1h') {
-          groupFrom = djsNow.subtract(
-            parseInt(period, 10),
-            _last(period) as dayjs.ManipulateType,
-          )
-        } else {
-          groupFrom = djsNow.subtract(
-            parseInt(period, 10) - 1,
-            _last(period) as dayjs.ManipulateType,
-          )
-        }
+        groupFrom = djsNow.subtract(
+          parseInt(period, 10),
+          _last(period) as dayjs.ManipulateType,
+        )
 
         groupFrom = groupFrom.startOf(timeBucket)
         groupTo = djsNow

--- a/backend/apps/cloud/src/analytics/analytics.service.ts
+++ b/backend/apps/cloud/src/analytics/analytics.service.ts
@@ -1226,7 +1226,10 @@ export class AnalyticsService {
         )
       }
 
-      groupFromUTC = groupFrom.utc().startOf(timeBucket).format(formatFrom)
+      // groupFrom is already rounded to the bucket in the project's timezone;
+      // rounding again after the UTC conversion would shift the boundary for
+      // timezones with a non-whole-hour offset (e.g. Asia/Kathmandu)
+      groupFromUTC = groupFrom.utc().format(formatFrom)
       groupToUTC = groupTo.utc().format(formatFrom)
     } else {
       throw new BadRequestException(

--- a/backend/apps/cloud/src/analytics/analytics.service.ts
+++ b/backend/apps/cloud/src/analytics/analytics.service.ts
@@ -579,17 +579,30 @@ export const getLowestPossibleTimeBucket = (
 
 // getAnalyticsSummary may be called without an explicit timeBucket (the v2
 // traffic summary endpoint never sends one). getGroupFromTo rounds the
-// window's lower boundary down to the bucket, so the fallback must be the
-// lowest bucket the period allows — a fixed DAY fallback would turn
-// `period=1h` into "since midnight"
+// window's lower boundary down to the bucket, so the period-only fallback
+// must be the lowest bucket the period allows — a fixed DAY fallback would
+// turn `period=1h` into "since midnight"
 export const getSummaryTimeBucket = (
   timeBucket?: string,
   period?: string,
   from?: string,
   to?: string,
-): TimeBucketType =>
-  (timeBucket as TimeBucketType) ||
-  getLowestPossibleTimeBucket(period, from, to)
+): TimeBucketType => {
+  if (timeBucket) {
+    return timeBucket as TimeBucketType
+  }
+
+  // Preserve the legacy fallback for custom or partial ranges: passing them
+  // to getLowestPossibleTimeBucket could throw a misleading range-length
+  // error before getGroupFromTo runs its own validation
+  if (from || to || !period) {
+    return ['today', 'yesterday', 'custom'].includes(period ?? '')
+      ? TimeBucketType.HOUR
+      : TimeBucketType.DAY
+  }
+
+  return getLowestPossibleTimeBucket(period)
+}
 
 const EXCLUDE_NULL_FOR = [
   'so',

--- a/backend/apps/cloud/src/analytics/analytics.service.ts
+++ b/backend/apps/cloud/src/analytics/analytics.service.ts
@@ -577,6 +577,20 @@ export const getLowestPossibleTimeBucket = (
   return _head(tbMap.tb)
 }
 
+// getAnalyticsSummary may be called without an explicit timeBucket (the v2
+// traffic summary endpoint never sends one). getGroupFromTo rounds the
+// window's lower boundary down to the bucket, so the fallback must be the
+// lowest bucket the period allows — a fixed DAY fallback would turn
+// `period=1h` into "since midnight"
+export const getSummaryTimeBucket = (
+  timeBucket?: string,
+  period?: string,
+  from?: string,
+  to?: string,
+): TimeBucketType =>
+  (timeBucket as TimeBucketType) ||
+  getLowestPossibleTimeBucket(period, from, to)
+
 const EXCLUDE_NULL_FOR = [
   'so',
   'me',
@@ -4885,12 +4899,12 @@ export class AnalyticsService {
   ): Promise<IOverall> {
     const safeTimezone = this.getSafeTimezone(timezone)
 
-    // Determine the time bucket for chart data
-    const effectiveTimeBucket = ['today', 'yesterday', 'custom'].includes(
+    const effectiveTimeBucket = getSummaryTimeBucket(
+      timeBucket,
       period,
+      from,
+      to,
     )
-      ? TimeBucketType.HOUR
-      : (timeBucket as TimeBucketType) || TimeBucketType.DAY
 
     const { groupFrom, groupTo, groupFromUTC, groupToUTC } =
       this.getGroupFromTo(

--- a/backend/apps/cloud/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
+++ b/backend/apps/cloud/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
@@ -1,4 +1,8 @@
-import { AnalyticsService, getSummaryTimeBucket } from '../../analytics.service'
+import {
+  AnalyticsService,
+  getLowestPossibleTimeBucket,
+  getSummaryTimeBucket,
+} from '../../analytics.service'
 import { TimeBucketType } from '../../dto/getData.dto'
 
 // getGroupFromTo does not touch `this`, so it can be exercised without
@@ -74,15 +78,59 @@ describe('traffic summary window (no explicit timeBucket)', () => {
     expect(groupToUTC).toBe('2026-08-23 14:37:42')
   })
 
-  it('period=7d starts six days ago on an hour boundary', () => {
+  it('period=7d starts seven days ago on an hour boundary', () => {
     const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
       '7d',
       'Etc/GMT',
     )
 
     expect(bucket).toBe(TimeBucketType.HOUR)
-    expect(groupFrom).toBe('2026-08-17 14:00:00')
-    expect(groupFromUTC).toBe('2026-08-17 14:00:00')
+    expect(groupFrom).toBe('2026-08-16 14:00:00')
+    expect(groupFromUTC).toBe('2026-08-16 14:00:00')
+  })
+
+  it('period=4w starts four weeks ago on a day boundary', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '4w',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.DAY)
+    expect(groupFrom).toBe('2026-07-26 00:00:00')
+    expect(groupFromUTC).toBe('2026-07-26 00:00:00')
+  })
+
+  it('period=3M starts three months ago on a day boundary, not a month boundary', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '3M',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.DAY)
+    expect(groupFrom).toBe('2026-05-23 00:00:00')
+    expect(groupFromUTC).toBe('2026-05-23 00:00:00')
+  })
+
+  it('period=12M starts twelve months ago on a day boundary', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '12M',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.DAY)
+    expect(groupFrom).toBe('2025-08-23 00:00:00')
+    expect(groupFromUTC).toBe('2025-08-23 00:00:00')
+  })
+
+  it('period=24M starts on the month boundary twenty-four months back', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '24M',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.MONTH)
+    expect(groupFrom).toBe('2024-08-01 00:00:00')
+    expect(groupFromUTC).toBe('2024-08-01 00:00:00')
   })
 
   it('period=today still starts at midnight', () => {
@@ -100,6 +148,15 @@ describe('traffic summary window (no explicit timeBucket)', () => {
     expect(getSummaryTimeBucket('day', '1h', undefined, undefined)).toBe(
       TimeBucketType.DAY,
     )
+  })
+
+  it('3M and 12M resolve to a day bucket in both resolvers, keeping cards and chart aligned', () => {
+    for (const period of ['3M', '12M']) {
+      expect(getLowestPossibleTimeBucket(period)).toBe(TimeBucketType.DAY)
+      expect(
+        getSummaryTimeBucket(undefined, period, undefined, undefined),
+      ).toBe(TimeBucketType.DAY)
+    }
   })
 
   it('partial and invalid custom ranges keep the legacy fallback and are left to getGroupFromTo to validate', () => {

--- a/backend/apps/cloud/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
+++ b/backend/apps/cloud/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
@@ -60,6 +60,20 @@ describe('traffic summary window (no explicit timeBucket)', () => {
     expect(groupFromUTC).toBe('2026-08-22 14:00:00')
   })
 
+  it('period=1d keeps the local hour boundary when converted to UTC for non-whole-hour offsets', () => {
+    // Asia/Kathmandu is UTC+05:45: the local 20:00 boundary is 14:15 UTC and
+    // must not be rounded again to 14:00 after the conversion
+    const { bucket, groupFrom, groupFromUTC, groupToUTC } = getSummaryWindow(
+      '1d',
+      'Asia/Kathmandu',
+    )
+
+    expect(bucket).toBe(TimeBucketType.HOUR)
+    expect(groupFrom).toBe('2026-08-22 20:00:00')
+    expect(groupFromUTC).toBe('2026-08-22 14:15:00')
+    expect(groupToUTC).toBe('2026-08-23 14:37:42')
+  })
+
   it('period=7d starts six days ago on an hour boundary', () => {
     const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
       '7d',

--- a/backend/apps/cloud/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
+++ b/backend/apps/cloud/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
@@ -1,0 +1,68 @@
+import { AnalyticsService, getSummaryTimeBucket } from '../../analytics.service'
+import { TimeBucketType } from '../../dto/getData.dto'
+
+// getGroupFromTo does not touch `this`, so it can be exercised without
+// instantiating the service and its DI graph
+const getGroupFromTo = AnalyticsService.prototype.getGroupFromTo.bind(
+  null as unknown as AnalyticsService,
+)
+
+// Mirrors how getAnalyticsSummary computes the summary window: the resolved
+// bucket is fed to getGroupFromTo with no from/to, no diff and no timebucket
+// validation
+const getSummaryWindow = (period: string, timezone: string) => {
+  const bucket = getSummaryTimeBucket(undefined, period, undefined, undefined)
+
+  return {
+    bucket,
+    ...getGroupFromTo(
+      undefined as unknown as string,
+      undefined as unknown as string,
+      bucket,
+      period,
+      timezone,
+      undefined,
+      false,
+    ),
+  }
+}
+
+describe('traffic summary window (no explicit timeBucket)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-23T14:37:42Z'))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('period=1h starts one hour ago on a minute boundary, not at midnight', () => {
+    const { bucket, groupFrom, groupFromUTC, groupTo } = getSummaryWindow(
+      '1h',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.MINUTE)
+    expect(groupFrom).toBe('2026-08-23 13:37:00')
+    expect(groupFromUTC).toBe('2026-08-23 13:37:00')
+    expect(groupTo).toBe('2026-08-23 14:37:42')
+  })
+
+  it('period=today still starts at midnight', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      'today',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.HOUR)
+    expect(groupFrom).toBe('2026-08-23 00:00:00')
+    expect(groupFromUTC).toBe('2026-08-23 00:00:00')
+  })
+
+  it('an explicitly requested timeBucket takes precedence', () => {
+    expect(getSummaryTimeBucket('day', '1h', undefined, undefined)).toBe(
+      TimeBucketType.DAY,
+    )
+  })
+})

--- a/backend/apps/cloud/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
+++ b/backend/apps/cloud/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
@@ -49,6 +49,28 @@ describe('traffic summary window (no explicit timeBucket)', () => {
     expect(groupTo).toBe('2026-08-23 14:37:42')
   })
 
+  it('period=1d starts one day ago on an hour boundary, not at midnight', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '1d',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.HOUR)
+    expect(groupFrom).toBe('2026-08-22 14:00:00')
+    expect(groupFromUTC).toBe('2026-08-22 14:00:00')
+  })
+
+  it('period=7d starts six days ago on an hour boundary', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '7d',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.HOUR)
+    expect(groupFrom).toBe('2026-08-17 14:00:00')
+    expect(groupFromUTC).toBe('2026-08-17 14:00:00')
+  })
+
   it('period=today still starts at midnight', () => {
     const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
       'today',
@@ -64,5 +86,29 @@ describe('traffic summary window (no explicit timeBucket)', () => {
     expect(getSummaryTimeBucket('day', '1h', undefined, undefined)).toBe(
       TimeBucketType.DAY,
     )
+  })
+
+  it('partial and invalid custom ranges keep the legacy fallback and are left to getGroupFromTo to validate', () => {
+    // Ranges must not be interpreted by getLowestPossibleTimeBucket: its NaN
+    // diff would throw a misleading range-length error before getGroupFromTo
+    // returns the correct validation error
+    expect(
+      getSummaryTimeBucket(undefined, undefined, '2026-08-20', undefined),
+    ).toBe(TimeBucketType.DAY)
+    expect(
+      getSummaryTimeBucket(undefined, 'custom', 'not-a-date', '2026-08-23'),
+    ).toBe(TimeBucketType.HOUR)
+
+    expect(() =>
+      getGroupFromTo(
+        'not-a-date',
+        '2026-08-23',
+        getSummaryTimeBucket(undefined, 'custom', 'not-a-date', '2026-08-23'),
+        'custom',
+        'Etc/GMT',
+        undefined,
+        false,
+      ),
+    ).toThrow("The timeframe 'from' parameter is invalid")
   })
 })

--- a/backend/apps/community/src/analytics/analytics.service.ts
+++ b/backend/apps/community/src/analytics/analytics.service.ts
@@ -1033,7 +1033,10 @@ export class AnalyticsService {
         )
       }
 
-      groupFromUTC = groupFrom.utc().startOf(timeBucket).format(formatFrom)
+      // groupFrom is already rounded to the bucket in the project's timezone;
+      // rounding again after the UTC conversion would shift the boundary for
+      // timezones with a non-whole-hour offset (e.g. Asia/Kathmandu)
+      groupFromUTC = groupFrom.utc().format(formatFrom)
       groupToUTC = groupTo.utc().format(formatFrom)
     } else {
       throw new BadRequestException(

--- a/backend/apps/community/src/analytics/analytics.service.ts
+++ b/backend/apps/community/src/analytics/analytics.service.ts
@@ -332,6 +332,20 @@ export const getLowestPossibleTimeBucket = (
   return _head(tbMap.tb)
 }
 
+// getAnalyticsSummary may be called without an explicit timeBucket (the v2
+// traffic summary endpoint never sends one). getGroupFromTo rounds the
+// window's lower boundary down to the bucket, so the fallback must be the
+// lowest bucket the period allows — a fixed DAY fallback would turn
+// `period=1h` into "since midnight"
+export const getSummaryTimeBucket = (
+  timeBucket?: string,
+  period?: string,
+  from?: string,
+  to?: string,
+): TimeBucketType =>
+  (timeBucket as TimeBucketType) ||
+  getLowestPossibleTimeBucket(period, from, to)
+
 const checkIfTBAllowed = (
   timeBucket: TimeBucketType,
   from: string,
@@ -3489,12 +3503,12 @@ export class AnalyticsService {
   ): Promise<IOverall> {
     const safeTimezone = this.getSafeTimezone(timezone)
 
-    // Determine the time bucket for chart data
-    const effectiveTimeBucket = ['today', 'yesterday', 'custom'].includes(
+    const effectiveTimeBucket = getSummaryTimeBucket(
+      timeBucket,
       period,
+      from,
+      to,
     )
-      ? TimeBucketType.HOUR
-      : (timeBucket as TimeBucketType) || TimeBucketType.DAY
 
     const { groupFrom, groupTo, groupFromUTC, groupToUTC } =
       this.getGroupFromTo(

--- a/backend/apps/community/src/analytics/analytics.service.ts
+++ b/backend/apps/community/src/analytics/analytics.service.ts
@@ -334,17 +334,30 @@ export const getLowestPossibleTimeBucket = (
 
 // getAnalyticsSummary may be called without an explicit timeBucket (the v2
 // traffic summary endpoint never sends one). getGroupFromTo rounds the
-// window's lower boundary down to the bucket, so the fallback must be the
-// lowest bucket the period allows — a fixed DAY fallback would turn
-// `period=1h` into "since midnight"
+// window's lower boundary down to the bucket, so the period-only fallback
+// must be the lowest bucket the period allows — a fixed DAY fallback would
+// turn `period=1h` into "since midnight"
 export const getSummaryTimeBucket = (
   timeBucket?: string,
   period?: string,
   from?: string,
   to?: string,
-): TimeBucketType =>
-  (timeBucket as TimeBucketType) ||
-  getLowestPossibleTimeBucket(period, from, to)
+): TimeBucketType => {
+  if (timeBucket) {
+    return timeBucket as TimeBucketType
+  }
+
+  // Preserve the legacy fallback for custom or partial ranges: passing them
+  // to getLowestPossibleTimeBucket could throw a misleading range-length
+  // error before getGroupFromTo runs its own validation
+  if (from || to || !period) {
+    return ['today', 'yesterday', 'custom'].includes(period ?? '')
+      ? TimeBucketType.HOUR
+      : TimeBucketType.DAY
+  }
+
+  return getLowestPossibleTimeBucket(period)
+}
 
 const checkIfTBAllowed = (
   timeBucket: TimeBucketType,

--- a/backend/apps/community/src/analytics/analytics.service.ts
+++ b/backend/apps/community/src/analytics/analytics.service.ts
@@ -308,11 +308,14 @@ export const getLowestPossibleTimeBucket = (
       return TimeBucketType.HOUR
     }
 
-    if (period === '4w') {
+    // The finest buckets must match the frontend's per-period options
+    // (tbPeriodPairs), otherwise summary cards and the chart cover
+    // different boundaries
+    if (period === '4w' || period === '3M' || period === '12M') {
       return TimeBucketType.DAY
     }
 
-    if (period === '3M' || period === '12M' || period === '24M') {
+    if (period === '24M') {
       return TimeBucketType.MONTH
     }
 
@@ -1009,17 +1012,10 @@ export class AnalyticsService {
         groupFrom = djsNow.subtract(diff - 1, 'day').startOf(timeBucket)
         groupTo = djsNow
       } else {
-        if (period === '1d' || period === '1h') {
-          groupFrom = djsNow.subtract(
-            parseInt(period, 10),
-            _last(period) as dayjs.ManipulateType,
-          )
-        } else {
-          groupFrom = djsNow.subtract(
-            parseInt(period, 10) - 1,
-            _last(period) as dayjs.ManipulateType,
-          )
-        }
+        groupFrom = djsNow.subtract(
+          parseInt(period, 10),
+          _last(period) as dayjs.ManipulateType,
+        )
 
         groupFrom = groupFrom.startOf(timeBucket)
         groupTo = djsNow

--- a/backend/apps/community/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
+++ b/backend/apps/community/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
@@ -1,4 +1,8 @@
-import { AnalyticsService, getSummaryTimeBucket } from '../../analytics.service'
+import {
+  AnalyticsService,
+  getLowestPossibleTimeBucket,
+  getSummaryTimeBucket,
+} from '../../analytics.service'
 import { TimeBucketType } from '../../dto/getData.dto'
 
 // getGroupFromTo does not touch `this`, so it can be exercised without
@@ -74,15 +78,59 @@ describe('traffic summary window (no explicit timeBucket)', () => {
     expect(groupToUTC).toBe('2026-08-23 14:37:42')
   })
 
-  it('period=7d starts six days ago on an hour boundary', () => {
+  it('period=7d starts seven days ago on an hour boundary', () => {
     const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
       '7d',
       'Etc/GMT',
     )
 
     expect(bucket).toBe(TimeBucketType.HOUR)
-    expect(groupFrom).toBe('2026-08-17 14:00:00')
-    expect(groupFromUTC).toBe('2026-08-17 14:00:00')
+    expect(groupFrom).toBe('2026-08-16 14:00:00')
+    expect(groupFromUTC).toBe('2026-08-16 14:00:00')
+  })
+
+  it('period=4w starts four weeks ago on a day boundary', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '4w',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.DAY)
+    expect(groupFrom).toBe('2026-07-26 00:00:00')
+    expect(groupFromUTC).toBe('2026-07-26 00:00:00')
+  })
+
+  it('period=3M starts three months ago on a day boundary, not a month boundary', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '3M',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.DAY)
+    expect(groupFrom).toBe('2026-05-23 00:00:00')
+    expect(groupFromUTC).toBe('2026-05-23 00:00:00')
+  })
+
+  it('period=12M starts twelve months ago on a day boundary', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '12M',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.DAY)
+    expect(groupFrom).toBe('2025-08-23 00:00:00')
+    expect(groupFromUTC).toBe('2025-08-23 00:00:00')
+  })
+
+  it('period=24M starts on the month boundary twenty-four months back', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '24M',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.MONTH)
+    expect(groupFrom).toBe('2024-08-01 00:00:00')
+    expect(groupFromUTC).toBe('2024-08-01 00:00:00')
   })
 
   it('period=today still starts at midnight', () => {
@@ -100,6 +148,15 @@ describe('traffic summary window (no explicit timeBucket)', () => {
     expect(getSummaryTimeBucket('day', '1h', undefined, undefined)).toBe(
       TimeBucketType.DAY,
     )
+  })
+
+  it('3M and 12M resolve to a day bucket in both resolvers, keeping cards and chart aligned', () => {
+    for (const period of ['3M', '12M']) {
+      expect(getLowestPossibleTimeBucket(period)).toBe(TimeBucketType.DAY)
+      expect(
+        getSummaryTimeBucket(undefined, period, undefined, undefined),
+      ).toBe(TimeBucketType.DAY)
+    }
   })
 
   it('partial and invalid custom ranges keep the legacy fallback and are left to getGroupFromTo to validate', () => {

--- a/backend/apps/community/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
+++ b/backend/apps/community/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
@@ -60,6 +60,20 @@ describe('traffic summary window (no explicit timeBucket)', () => {
     expect(groupFromUTC).toBe('2026-08-22 14:00:00')
   })
 
+  it('period=1d keeps the local hour boundary when converted to UTC for non-whole-hour offsets', () => {
+    // Asia/Kathmandu is UTC+05:45: the local 20:00 boundary is 14:15 UTC and
+    // must not be rounded again to 14:00 after the conversion
+    const { bucket, groupFrom, groupFromUTC, groupToUTC } = getSummaryWindow(
+      '1d',
+      'Asia/Kathmandu',
+    )
+
+    expect(bucket).toBe(TimeBucketType.HOUR)
+    expect(groupFrom).toBe('2026-08-22 20:00:00')
+    expect(groupFromUTC).toBe('2026-08-22 14:15:00')
+    expect(groupToUTC).toBe('2026-08-23 14:37:42')
+  })
+
   it('period=7d starts six days ago on an hour boundary', () => {
     const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
       '7d',

--- a/backend/apps/community/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
+++ b/backend/apps/community/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
@@ -1,0 +1,68 @@
+import { AnalyticsService, getSummaryTimeBucket } from '../../analytics.service'
+import { TimeBucketType } from '../../dto/getData.dto'
+
+// getGroupFromTo does not touch `this`, so it can be exercised without
+// instantiating the service and its DI graph
+const getGroupFromTo = AnalyticsService.prototype.getGroupFromTo.bind(
+  null as unknown as AnalyticsService,
+)
+
+// Mirrors how getAnalyticsSummary computes the summary window: the resolved
+// bucket is fed to getGroupFromTo with no from/to, no diff and no timebucket
+// validation
+const getSummaryWindow = (period: string, timezone: string) => {
+  const bucket = getSummaryTimeBucket(undefined, period, undefined, undefined)
+
+  return {
+    bucket,
+    ...getGroupFromTo(
+      undefined as unknown as string,
+      undefined as unknown as string,
+      bucket,
+      period,
+      timezone,
+      undefined,
+      false,
+    ),
+  }
+}
+
+describe('traffic summary window (no explicit timeBucket)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-08-23T14:37:42Z'))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('period=1h starts one hour ago on a minute boundary, not at midnight', () => {
+    const { bucket, groupFrom, groupFromUTC, groupTo } = getSummaryWindow(
+      '1h',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.MINUTE)
+    expect(groupFrom).toBe('2026-08-23 13:37:00')
+    expect(groupFromUTC).toBe('2026-08-23 13:37:00')
+    expect(groupTo).toBe('2026-08-23 14:37:42')
+  })
+
+  it('period=today still starts at midnight', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      'today',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.HOUR)
+    expect(groupFrom).toBe('2026-08-23 00:00:00')
+    expect(groupFromUTC).toBe('2026-08-23 00:00:00')
+  })
+
+  it('an explicitly requested timeBucket takes precedence', () => {
+    expect(getSummaryTimeBucket('day', '1h', undefined, undefined)).toBe(
+      TimeBucketType.DAY,
+    )
+  })
+})

--- a/backend/apps/community/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
+++ b/backend/apps/community/src/analytics/v2/__tests__/summary-time-bucket.spec.ts
@@ -49,6 +49,28 @@ describe('traffic summary window (no explicit timeBucket)', () => {
     expect(groupTo).toBe('2026-08-23 14:37:42')
   })
 
+  it('period=1d starts one day ago on an hour boundary, not at midnight', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '1d',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.HOUR)
+    expect(groupFrom).toBe('2026-08-22 14:00:00')
+    expect(groupFromUTC).toBe('2026-08-22 14:00:00')
+  })
+
+  it('period=7d starts six days ago on an hour boundary', () => {
+    const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
+      '7d',
+      'Etc/GMT',
+    )
+
+    expect(bucket).toBe(TimeBucketType.HOUR)
+    expect(groupFrom).toBe('2026-08-17 14:00:00')
+    expect(groupFromUTC).toBe('2026-08-17 14:00:00')
+  })
+
   it('period=today still starts at midnight', () => {
     const { bucket, groupFrom, groupFromUTC } = getSummaryWindow(
       'today',
@@ -64,5 +86,29 @@ describe('traffic summary window (no explicit timeBucket)', () => {
     expect(getSummaryTimeBucket('day', '1h', undefined, undefined)).toBe(
       TimeBucketType.DAY,
     )
+  })
+
+  it('partial and invalid custom ranges keep the legacy fallback and are left to getGroupFromTo to validate', () => {
+    // Ranges must not be interpreted by getLowestPossibleTimeBucket: its NaN
+    // diff would throw a misleading range-length error before getGroupFromTo
+    // returns the correct validation error
+    expect(
+      getSummaryTimeBucket(undefined, undefined, '2026-08-20', undefined),
+    ).toBe(TimeBucketType.DAY)
+    expect(
+      getSummaryTimeBucket(undefined, 'custom', 'not-a-date', '2026-08-23'),
+    ).toBe(TimeBucketType.HOUR)
+
+    expect(() =>
+      getGroupFromTo(
+        'not-a-date',
+        '2026-08-23',
+        getSummaryTimeBucket(undefined, 'custom', 'not-a-date', '2026-08-23'),
+        'custom',
+        'Etc/GMT',
+        undefined,
+        false,
+      ),
+    ).toThrow("The timeframe 'from' parameter is invalid")
   })
 })


### PR DESCRIPTION
### Changes

This PR fixes four related timeframe bugs in the traffic analytics backend. The starting symptom: `GET /v2/projects/:pid/traffic/summary?period=1h` returned totals since midnight in the summary cards, while the chart and the Profiles list correctly showed the last hour. Investigating it surfaced three more boundary bugs in the same resolution path.

1. Summary bucket fallback. The v2 traffic summary endpoint calls `getAnalyticsSummary()` without an explicit `timeBucket`, and the fallback resolved `period=1h` to `TimeBucketType.DAY`. `getGroupFromTo()` rounds the lower window boundary down with `.startOf(timeBucket)`, so "one hour ago" became midnight. A new `getSummaryTimeBucket()` helper now resolves period-only requests with `getLowestPossibleTimeBucket(period)`, the same resolver the v2 chart's `resolveTimeframe()` uses. An explicit `timeBucket` still wins, and requests with custom, partial or invalid `from`/`to` values keep the old fallback and still go through the validation in `getGroupFromTo()`.

2. Rolling presets were one unit short. `getGroupFromTo()` subtracted `N - 1` units for every rolling period except `1h` and `1d`, so `7d` covered 6 days, `4w` covered 3 weeks, `3M` covered 2 months, `12M` covered 11 and `24M` covered 23. The subtraction now always uses the full numeric amount. `today`, `yesterday` and `all` keep their separate handling.

3. Finest-bucket mapping disagreed with the frontend. `getLowestPossibleTimeBucket()` returned `MONTH` for `3M` and `12M`, while the frontend offers `day` as the finest bucket for those presets (`tbPeriodPairs`). Summary cards could therefore start at the beginning of a month while the daily chart started later. The mapping is now `1h` to `MINUTE`; `today`, `yesterday`, `1d`, `7d` to `HOUR`; `4w`, `3M`, `12M` to `DAY`; `24M` to `MONTH`.

4. UTC conversion re-rounded already-aligned boundaries. `groupFrom` is rounded to the bucket in the project's timezone, but the period path rounded it again after converting to UTC. For non-whole-hour offsets such as Asia/Kathmandu (UTC+05:45), a local 20:00 boundary is 14:15 UTC and was pulled back to 14:00. For whole-hour offsets with day or coarser buckets the second rounding could widen the window by up to a day. The conversion now preserves the aligned instant.

Regression tests in both apps run the summary resolution through `getGroupFromTo()` under a frozen clock and assert `groupFrom` and `groupFromUTC` for every preset: `1h` (minute boundary one hour back), `1d` and `7d` (hour boundaries one and seven days back), `4w`, `3M` and `12M` (day boundaries the full amount back), `24M` (month boundary), `today` (midnight). Further tests cover the Asia/Kathmandu 14:15 UTC boundary, explicit `timeBucket` precedence, the legacy fallback with partial or invalid ranges, and that both resolvers return `DAY` for `3M` and `12M` so cards and chart stay aligned.

Validated with `npm run format:check`, `lint`, `lint:tsc`, `knip`, `test:v2` (175 passed) and `deploy:community`.

### Community Edition support
- [x] Your feature is implemented for the Swetrix Community Edition
- [ ] This PR only updates the Cloud (Enterprise) Edition code (e.g. Paddle webhooks, blog, payouts, etc.)

### Database migrations
- [ ] Clickhouse / MySQL migrations added for this PR
- [x] No table schemas changed in this PR

### Documentation
- [ ] You have updated the [documentation](https://github.com/swetrix/docs) according to your PR
- [x] This PR did not change any publicly documented endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics summary time ranges for 7-day, 4-week, 3-month, 12-month, and 24-month periods.
  * Corrected timezone boundary handling for more accurate date ranges.
  * Ensured 3-month and 12-month summaries use daily detail, while 24-month summaries use monthly detail.
  * Preserved explicit time-bucket selections and improved fallback behavior for custom ranges.

* **Tests**
  * Added coverage for period resolution, timezone conversion, boundary handling, and custom-range validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->